### PR TITLE
bugfix (SiderMenu.tsx, TAPage.tsx, TPLayout.tsx, index.tsx): 修复侧边栏收缩後主页面不变化的bug

### DIFF
--- a/src/layouts/SiderMenu.tsx
+++ b/src/layouts/SiderMenu.tsx
@@ -78,20 +78,37 @@ const pathToKeyMap: { [path: string]: string } = {
   '/eventanalysis': 'eventanalysis',
 };
 
-const SiderMenu: React.FC = () => {
+// 要向父组件传递收缩状态，使得主页面得知收缩状态後也要收缩
+interface SiderMenuProps {
+  onCollapse?: (collapsed: boolean) => void;
+}
+
+const SiderMenu: React.FC<SiderMenuProps> = ({ onCollapse }) => {
   const location = useLocation();
   const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
+  const [collapsed, setCollapsed] = useState(false);
 
   useEffect(() => {
     const key = pathToKeyMap[location.pathname] || 'home';
     setSelectedKeys([key]);
   }, [location.pathname]);
 
+  // 处理收缩状态变化
+  const handleCollapse = (isCollapsed: boolean) => {
+    setCollapsed(isCollapsed);
+    if (onCollapse) {
+      onCollapse(isCollapsed);
+    }
+  };
+
   return (
     <Sider
       collapsible
+      collapsed={collapsed}
+      onCollapse={handleCollapse}
       theme="light"
-      width={210}
+      width={210}          // 展开的宽度
+      collapsedWidth={80}  // 收缩的宽度
       style={{
         position: 'fixed',
         height: '100vh',

--- a/src/layouts/TrackPointLayout.tsx
+++ b/src/layouts/TrackPointLayout.tsx
@@ -1,9 +1,9 @@
-import { Layout,Menu } from 'antd';
-import { Outlet,Link } from 'react-router-dom';
+import { Layout, Menu } from 'antd';
+import React, { useState } from 'react';
+import { Outlet, Link } from 'react-router-dom';
 import AppHeader from './Header';
 
 const { Content } = Layout;
-
 
 import {
   ProfileOutlined,
@@ -34,12 +34,22 @@ const items: MenuItem[] = [{
     ],
   },]
 
-const SiderMenu = () => {
+const SiderMenu = ({ onCollapse }: { onCollapse: (collapsed: boolean) => void }) => {
+  const [collapsed, setCollapsed] = useState(false);
+  
+  const handleCollapse = (isCollapsed: boolean) => {
+    setCollapsed(isCollapsed);
+    onCollapse(isCollapsed);
+  };
+  
   return (
     <Sider
       collapsible
+      collapsed={collapsed}
+      onCollapse={handleCollapse}
       theme="light"
       width={210}
+      collapsedWidth={80}
       style={{
         position: 'fixed',
         height: '100vh',
@@ -60,13 +70,22 @@ const SiderMenu = () => {
 };
 
 
-export default function TrackPointLayout() {
+const TrackPointLayout: React.FC = () => {
+  // 和主页面 index.tsx 的实现一样，不再赘述
+  const [siderCollapsed, setSiderCollapsed] = useState(false);
+
+  const handleSiderCollapse = (collapsed: boolean) => {
+    setSiderCollapsed(collapsed);
+  };
+
   return (
     <Layout style={{ minHeight: '100vh' }}>
-      {/* 侧边栏 */}
+      <SiderMenu onCollapse={handleSiderCollapse} />
       
-    <SiderMenu />
-      <Layout style={{ marginLeft: 200 }}>
+      <Layout style={{ 
+        marginLeft: siderCollapsed ? 80 : 210,
+        transition: 'margin-left 0.2s'
+      }}>
         {/* 顶部导航栏 */}
         <AppHeader />
 
@@ -83,4 +102,6 @@ export default function TrackPointLayout() {
       </Layout>
     </Layout>
   );
-}
+};
+
+export default TrackPointLayout;

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -2,16 +2,29 @@ import { Layout } from 'antd';
 import { Outlet } from 'react-router-dom';
 import SiderMenu from './SiderMenu';
 import AppHeader from './Header';
+import { useState } from 'react';
 
 const { Content } = Layout;
 
 export default function MainLayout() {
+  // 跟踪侧边栏是否收缩
+  const [siderCollapsed, setSiderCollapsed] = useState(false);
+
+  // 处理侧边栏收缩状态变化
+  const handleSiderCollapse = (collapsed: boolean) => {
+    setSiderCollapsed(collapsed);
+  };
+
   return (
     <Layout style={{ minHeight: '100vh' }}>
       {/* 侧边栏 */}
-      <SiderMenu />
+      <SiderMenu onCollapse={handleSiderCollapse} />
 
-      <Layout style={{ marginLeft: 200 }}>
+      {/* 如果侧边栏收缩，那么左边缘到 80，即展开主页面 */}
+      <Layout style={{ 
+        marginLeft: siderCollapsed ? 80 : 210,
+        transition: 'margin-left 0.2s'
+      }}>
         {/* 顶部导航栏 */}
         <AppHeader />
 

--- a/src/pages/TrendAnalysisPage.tsx
+++ b/src/pages/TrendAnalysisPage.tsx
@@ -433,9 +433,9 @@ export default function TrendAnalysisPage() {
       {/* 固定 Header */}
       <div
         style={{
-          position: 'fixed',
-          top: 65, // 关键定位参数
-          width: '100%',
+          position: 'sticky',  // 改为sticky定位而不是fixed
+          top: 0,              // 调整顶部位置
+          width: 'auto',       // 宽度自动调整
           height: 93,
           zIndex: 1,
           background: '#fff',
@@ -470,8 +470,9 @@ export default function TrendAnalysisPage() {
       <Content style={{ marginTop: 78, padding: '0 0px' }}>
         <div style={{ background: '#fff', padding: 0, minHeight: '100vh' }}>
           {data ? <pre>{JSON.stringify(data, null, 2)}</pre> : <></>}
-          <Space direction="vertical" size={16}>
-            <Card title="" style={{ width: '80vw', height: 500 }}>
+          {/* 侧边栏会收缩，width 使用缩放，不能固定 */}
+          <Space direction="vertical" size={16} style={{ width: '100%' }}>
+            <Card title="" style={{ width: '100%', height: 500 }}>
               <h2>流量概览</h2>
               <Table
                 columns={columns}
@@ -483,10 +484,11 @@ export default function TrendAnalysisPage() {
               />
             </Card>
           </Space>
-          <Space direction="vertical" size={16}>
-            <Card style={{ width: '80vw', height: 500 }}>
+          <Space direction="vertical" size={16} style={{ width: '100%' }}>
+            <Card style={{ width: '100%', height: 500 }}>
               <h2>趋势图</h2>
-              <div ref={chartRef} style={{ width: '900', height: '400px' }} />
+              {/* 同理，width 使用缩放，不能固定 */}
+              <div ref={chartRef} style={{ width: '100%', height: '400px' }} />
             </Card>
           </Space>
         </div>


### PR DESCRIPTION
## 问题
在原始代码中，当用户点击侧边栏收缩按钮时，侧边栏能够正常收缩，但主内容区域没有相应扩展。

另外，在趋势分析一块，表格的宽度是固定的，导致扩展时是整个页面左移。

## 修改内容
修改了以下文件：

1. **`src/layouts/SiderMenu.tsx`**：

2. **`src/layouts/index.tsx`**：

3. **`src/layouts/TrackPointLayout.tsx`**：

4. **`src/pages/TrendAnalysisPage.tsx`**：

## 修复後
**侧边栏未收缩**：

![image](https://github.com/user-attachments/assets/47d1d9f1-e311-40e4-9f89-0fa3b1bd0d9f)


**侧边栏收缩**：

此时主页面可以利用收缩的空间

![image](https://github.com/user-attachments/assets/cb69267c-104e-44a4-840b-88a19268c9a4)